### PR TITLE
fix: specify provider name in tfplugindocs to prevent directory name inference

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var (
 )
 
 // Generate the Terraform provider documentation using `tfplugindocs`:
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name microsoft365
 
 func main() {
 	var debug bool


### PR DESCRIPTION
# Pull Request Description

  ## Summary

  Fix tfplugindocs provider name inference issue when generating documentation from non-standard directory names.

  ### Issue Reference

  N/A - This is a development tooling fix

  ### Motivation and Context

  - **Why is this change needed?** When working in git worktrees or branches with custom directory names (e.g.,
  `testing-dev-setup`), the `make userdocs` command fails because tfplugindocs infers the provider name from the
  directory name instead of using the correct provider name `microsoft365`.

  - **What problem does it solve?** This fix ensures documentation generation works consistently regardless of the
  working directory name by explicitly specifying the provider name in the go:generate directive.

  - **Context:** The error manifested as:
    data source entitled "testing-dev-setup", or
  "testing-dev-setup_graph_beta_device_and_app_management_application_category" does not exist

  ### Dependencies

  - No new dependencies required
  - No configuration changes needed
  - No version updates required

  ## Type of Change

  Please mark the relevant option with an `x`:

  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature (non-breaking change which adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] 📝 Documentation update (Wiki/README/Code comments)
  - [ ] ♻️ Refactor (code improvement without functional changes)
  - [ ] 🎨 Style update (formatting, renaming)
  - [ ] 🔧 Configuration change
  - [ ] 📦 Dependency update

  ## Testing

  - [ ] I have added unit tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have tested this code in the following browsers/environments: macOS Darwin 24.5.0

  ## Quality Checklist

  - [x] I have reviewed my own code before requesting review
  - [x] I have verified there are no other open Pull Requests for the same update/change
  - [x] All CI/CD pipelines pass without errors or warnings
  - [x] My code follows the established style guidelines of this project
  - [x] I have added necessary documentation (if appropriate)
  - [x] I have commented my code, particularly in complex areas
  - [x] My changes generate no new warnings
  - [x] I have performed a self-review of my own code
  - [x] My code is properly formatted according to project standards

  ## Screenshots/Recordings

  ### Before Fix:
  ```bash
  $ make userdocs
  go generate
  data source entitled "testing-dev-setup", or
  "testing-dev-setup_graph_beta_device_and_app_management_application_category" does not exist
  Error executing command: unable to generate website: error rendering static website

  After Fix:

  $ make userdocs
  go generate
  rendering website for provider "microsoft365" (as "microsoft365")
  ...
  tfplugindocs validate --provider-name microsoft365
  ✅ Success

  Additional Notes

  This fix adds generate --provider-name microsoft365 to the go:generate directive in main.go, ensuring tfplugindocs
  always uses the correct provider name regardless of the directory structure. The second commit contains the
  auto-generated documentation updates from running make userdocs successfully.
  ```