### PR TITLE
feat: derive GPG signing keys from SSM instead of GitHub Secrets

### DIFF
--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -77,8 +77,7 @@ jobs:
       release-notes: false
       setup-go-version-file: 'go.mod'
       git-ref: ${{ github.event.inputs.release_version || github.ref }}
-      aws-role-arn: arn:aws:iam::224746450967:role/terraform-provider-signing-role
-      aws-region: us-east-1
+      use-ssm-signing-keys: true
 
   release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -72,15 +72,13 @@ jobs:
     name: '📦 Terraform Provider Release'
     needs: [pre-release-checks]
     uses:  ./.github/workflows/tf-registry-goreleaser.yml
-    secrets:
-      gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'  # Your GPG private key
-      gpg-private-key-passphrase: '${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}'  # Passphrase for your GPG key, if applicable
     with:
       goreleaser-release-args: --verbose --parallelism 1 --timeout 120m0s # parallelism set to match the number of free cores on the runner
-
       release-notes: false
       setup-go-version-file: 'go.mod'
       git-ref: ${{ github.event.inputs.release_version || github.ref }}
+      aws-role-arn: arn:aws:iam::224746450967:role/terraform-provider-signing-role
+      aws-region: us-east-1
 
   release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/tf-registry-goreleaser.yml
+++ b/.github/workflows/tf-registry-goreleaser.yml
@@ -4,6 +4,7 @@ name: provider | Terraform Registry with goreleaser
 
 permissions:
   contents: write
+  id-token: write # Required for OIDC authentication to AWS
   packages: read
   statuses: write
 
@@ -30,12 +31,22 @@ on:
         description: 'branch, tag or SHA to checkout'
         required: false
         type: string
+      aws-role-arn:
+        description: 'AWS IAM Role ARN for OIDC authentication to fetch GPG signing keys from SSM'
+        required: false
+        type: string
+        default: ''
+      aws-region:
+        description: 'AWS region for SSM parameter lookup'
+        required: false
+        type: string
+        default: 'us-east-1'
     secrets:
       gpg-private-key:
-        description: 'GPG Private Key'
-        required: true
+        description: 'GPG Private Key (legacy: use aws-role-arn to fetch from SSM instead)'
+        required: false
       gpg-private-key-passphrase:
-        description: 'GPG Private Key Passphrase'
+        description: 'GPG Private Key Passphrase (legacy: use aws-role-arn to fetch from SSM instead)'
         required: false
 
 jobs:
@@ -60,22 +71,75 @@ jobs:
           go-version: ${{ inputs.setup-go-version }}
           go-version-file: ${{ inputs.setup-go-version-file }}
           cache: false  # Disable caching to skip the post-cleanup step. saves circa 15 minutes
-      - name: Import GPG key
-        id: import_gpg
+
+      # --- Path A: Fetch GPG signing keys from AWS SSM via OIDC ---
+      - name: Configure AWS credentials via OIDC
+        if: inputs.aws-role-arn != ''
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ inputs.aws-region }}
+
+      - name: Fetch and import GPG signing key from SSM
+        if: inputs.aws-role-arn != ''
+        id: ssm_gpg_import
+        run: |
+          GPG_PRIVATE_KEY=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-private-key" \
+            --with-decryption --query "Parameter.Value" --output text)
+          GPG_PASSPHRASE=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-private-key-passphrase" \
+            --with-decryption --query "Parameter.Value" --output text)
+          GPG_KEY_ID=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-key-id" \
+            --query "Parameter.Value" --output text)
+
+          echo "::add-mask::${GPG_PASSPHRASE}"
+
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import --passphrase "${GPG_PASSPHRASE}"
+
+          FINGERPRINT=$(gpg --list-keys --with-colons "${GPG_KEY_ID}" | awk -F: '/^fpr:/{print $10; exit}')
+
+          echo "fingerprint=${FINGERPRINT}" >> "$GITHUB_OUTPUT"
+          echo "keyid=${GPG_KEY_ID}" >> "$GITHUB_OUTPUT"
+
+          gpg --armor --export "${FINGERPRINT}" > gpg-public-key.asc
+          echo "GPG Key ID: ${GPG_KEY_ID}"
+          echo "GPG Fingerprint: ${FINGERPRINT}"
+          echo "GPG public key exported to gpg-public-key.asc"
+          echo "GPG signing keys derived from SSM parameters"
+
+      # --- Path B: Legacy - Import GPG key from GitHub Secrets ---
+      - name: Import GPG key from secrets
+        if: inputs.aws-role-arn == ''
+        id: import_gpg_legacy
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.gpg-private-key }}
           passphrase: ${{ secrets.gpg-private-key-passphrase }}
-      - name: Export GPG public key for registry verification
+
+      - name: Export GPG public key for registry verification (legacy)
+        if: inputs.aws-role-arn == ''
         run: |
-          gpg --armor --export "${{ steps.import_gpg.outputs.fingerprint }}" > gpg-public-key.asc
-          echo "GPG Key ID: ${{ steps.import_gpg.outputs.keyid }}"
-          echo "GPG Fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+          gpg --armor --export "${{ steps.import_gpg_legacy.outputs.fingerprint }}" > gpg-public-key.asc
+          echo "GPG Key ID: ${{ steps.import_gpg_legacy.outputs.keyid }}"
+          echo "GPG Fingerprint: ${{ steps.import_gpg_legacy.outputs.fingerprint }}"
           echo "GPG public key exported to gpg-public-key.asc"
           echo ""
           echo "To update the Terraform registry proxy SSM parameters, run:"
-          echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-key-id --value '${{ steps.import_gpg.outputs.keyid }}' --type String --overwrite"
+          echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-key-id --value '${{ steps.import_gpg_legacy.outputs.keyid }}' --type String --overwrite"
           echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-public-key --value \"\$(cat gpg-public-key.asc)\" --type SecureString --overwrite"
+
+      # --- Resolve GPG fingerprint from whichever path was used ---
+      - name: Set GPG fingerprint
+        id: gpg_fingerprint
+        run: |
+          if [ -n "${{ inputs.aws-role-arn }}" ]; then
+            echo "fingerprint=${{ steps.ssm_gpg_import.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "fingerprint=${{ steps.import_gpg_legacy.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - if: inputs.release-notes != true
         name: goreleaser release (without release notes)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
@@ -83,7 +147,7 @@ jobs:
           args: release --clean ${{ inputs.goreleaser-release-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.gpg_fingerprint.outputs.fingerprint }}
       - if: inputs.release-notes
         id: release-notes-download
         name: Release Notes Download
@@ -98,4 +162,4 @@ jobs:
           args: release --release-notes ${{ steps.release-notes-download.outputs.download-path }}/release-notes.txt --clean ${{ inputs.goreleaser-release-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.gpg_fingerprint.outputs.fingerprint }}

--- a/.github/workflows/tf-registry-goreleaser.yml
+++ b/.github/workflows/tf-registry-goreleaser.yml
@@ -4,7 +4,6 @@ name: provider | Terraform Registry with goreleaser
 
 permissions:
   contents: write
-  id-token: write # Required for OIDC authentication to AWS
   packages: read
   statuses: write
 
@@ -31,22 +30,17 @@ on:
         description: 'branch, tag or SHA to checkout'
         required: false
         type: string
-      aws-role-arn:
-        description: 'AWS IAM Role ARN for OIDC authentication to fetch GPG signing keys from SSM'
+      use-ssm-signing-keys:
+        description: 'Fetch GPG signing keys from AWS SSM Parameter Store instead of GitHub Secrets. Requires the runner to have SSM read access.'
         required: false
-        type: string
-        default: ''
-      aws-region:
-        description: 'AWS region for SSM parameter lookup'
-        required: false
-        type: string
-        default: 'us-east-1'
+        type: boolean
+        default: false
     secrets:
       gpg-private-key:
-        description: 'GPG Private Key (legacy: use aws-role-arn to fetch from SSM instead)'
+        description: 'GPG Private Key (legacy: use use-ssm-signing-keys instead)'
         required: false
       gpg-private-key-passphrase:
-        description: 'GPG Private Key Passphrase (legacy: use aws-role-arn to fetch from SSM instead)'
+        description: 'GPG Private Key Passphrase (legacy: use use-ssm-signing-keys instead)'
         required: false
 
 jobs:
@@ -72,16 +66,9 @@ jobs:
           go-version-file: ${{ inputs.setup-go-version-file }}
           cache: false  # Disable caching to skip the post-cleanup step. saves circa 15 minutes
 
-      # --- Path A: Fetch GPG signing keys from AWS SSM via OIDC ---
-      - name: Configure AWS credentials via OIDC
-        if: inputs.aws-role-arn != ''
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ inputs.aws-role-arn }}
-          aws-region: ${{ inputs.aws-region }}
-
+      # --- Path A: Fetch GPG signing keys from AWS SSM (runner instance credentials) ---
       - name: Fetch and import GPG signing key from SSM
-        if: inputs.aws-role-arn != ''
+        if: inputs.use-ssm-signing-keys
         id: ssm_gpg_import
         run: |
           GPG_PRIVATE_KEY=$(aws ssm get-parameter \
@@ -111,7 +98,7 @@ jobs:
 
       # --- Path B: Legacy - Import GPG key from GitHub Secrets ---
       - name: Import GPG key from secrets
-        if: inputs.aws-role-arn == ''
+        if: ${{ !inputs.use-ssm-signing-keys }}
         id: import_gpg_legacy
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
@@ -119,7 +106,7 @@ jobs:
           passphrase: ${{ secrets.gpg-private-key-passphrase }}
 
       - name: Export GPG public key for registry verification (legacy)
-        if: inputs.aws-role-arn == ''
+        if: ${{ !inputs.use-ssm-signing-keys }}
         run: |
           gpg --armor --export "${{ steps.import_gpg_legacy.outputs.fingerprint }}" > gpg-public-key.asc
           echo "GPG Key ID: ${{ steps.import_gpg_legacy.outputs.keyid }}"
@@ -134,7 +121,7 @@ jobs:
       - name: Set GPG fingerprint
         id: gpg_fingerprint
         run: |
-          if [ -n "${{ inputs.aws-role-arn }}" ]; then
+          if [ "${{ inputs.use-ssm-signing-keys }}" = "true" ]; then
             echo "fingerprint=${{ steps.ssm_gpg_import.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
           else
             echo "fingerprint=${{ steps.import_gpg_legacy.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tf-registry-goreleaser.yml
+++ b/.github/workflows/tf-registry-goreleaser.yml
@@ -81,11 +81,19 @@ jobs:
             --name "/terraform-registry-api-github-proxy/gpg-key-id" \
             --query "Parameter.Value" --output text)
 
+          # Mask sensitive values to prevent leaking in logs
+          echo "::add-mask::${GPG_PRIVATE_KEY}"
           echo "::add-mask::${GPG_PASSPHRASE}"
 
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import --passphrase "${GPG_PASSPHRASE}"
+          # Import the GPG key
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
 
           FINGERPRINT=$(gpg --list-keys --with-colons "${GPG_KEY_ID}" | awk -F: '/^fpr:/{print $10; exit}')
+
+          # Preset passphrase in GPG agent for batch signing (required for goreleaser)
+          KEYGRIP=$(gpg --batch --with-colons --with-keygrip --list-secret-keys "${GPG_KEY_ID}" | awk -F: '/^grp:/{print $10; exit}')
+          HEX_PASSPHRASE=$(echo -n "${GPG_PASSPHRASE}" | xxd -p -c 256 | tr -d '\n' | tr 'a-f' 'A-F')
+          gpg-connect-agent "PRESET_PASSPHRASE ${KEYGRIP} -1 ${HEX_PASSPHRASE}" /bye
 
           echo "fingerprint=${FINGERPRINT}" >> "$GITHUB_OUTPUT"
           echo "keyid=${GPG_KEY_ID}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Updates the reusable goreleaser workflow (`tf-registry-goreleaser.yml`) to fetch GPG signing keys from AWS SSM Parameter Store using the self-hosted runner's existing instance credentials
- Adds a `use-ssm-signing-keys` boolean input — when `true`, keys are fetched from SSM; when `false` (default), the legacy GitHub Secrets path is used
- Updates `provider-release.yml` to enable SSM signing keys and remove the `secrets:` block for `GPG_PRIVATE_KEY` / `GPG_PRIVATE_KEY_PASSPHRASE`

## How it works
The `ubuntu-xlarge` self-hosted runners already have `ssm:Get*` access on `Resource: *` via their instance profile. The workflow simply calls `aws ssm get-parameter` to fetch:
- `/terraform-registry-api-github-proxy/gpg-private-key`
- `/terraform-registry-api-github-proxy/gpg-private-key-passphrase`
- `/terraform-registry-api-github-proxy/gpg-key-id`

These are the **same SSM parameters** that [registry.sweetgreen.engineering](https://registry.sweetgreen.engineering) reads from, making SSM the single source of truth for signing keys across all `terraform-provider-*` repos and the registry.

## Dependencies
- Requires [sweetgreen/terraform-infrastructure#1130](https://github.com/sweetgreen/terraform-infrastructure/pull/1130) to be deployed first (creates the SSM parameters and populates them)

## Test plan
- [ ] Deploy terraform-infrastructure PR first and populate SSM params
- [ ] Trigger a manual `workflow_dispatch` release (e.g. `v0.0.0-alpha`) to verify SSM-based signing works
- [ ] Verify the release artifacts include a valid `SHA256SUMS.sig` signed by the SSM-derived key
- [ ] Confirm [registry.sweetgreen.engineering](https://registry.sweetgreen.engineering) returns the same GPG public key in download responses
- [ ] After validation, remove `GPG_PRIVATE_KEY` and `GPG_PRIVATE_KEY_PASSPHRASE` GitHub Secrets from this repo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sweetgreen/terraform-provider-microsoft365/pull/66">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
