### PR TITLE
feat(ci): derive GPG signing keys from SSM instead of GitHub Secrets

### DIFF
--- a/.github/workflows/provider-release.yml
+++ b/.github/workflows/provider-release.yml
@@ -72,15 +72,12 @@ jobs:
     name: '📦 Terraform Provider Release'
     needs: [pre-release-checks]
     uses:  ./.github/workflows/tf-registry-goreleaser.yml
-    secrets:
-      gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'  # Your GPG private key
-      gpg-private-key-passphrase: '${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}'  # Passphrase for your GPG key, if applicable
     with:
       goreleaser-release-args: --verbose --parallelism 1 --timeout 120m0s # parallelism set to match the number of free cores on the runner
-
       release-notes: false
       setup-go-version-file: 'go.mod'
       git-ref: ${{ github.event.inputs.release_version || github.ref }}
+      use-ssm-signing-keys: true
 
   release-notes:
     runs-on: ubuntu-latest

--- a/.github/workflows/tf-registry-goreleaser.yml
+++ b/.github/workflows/tf-registry-goreleaser.yml
@@ -30,12 +30,17 @@ on:
         description: 'branch, tag or SHA to checkout'
         required: false
         type: string
+      use-ssm-signing-keys:
+        description: 'Fetch GPG signing keys from AWS SSM Parameter Store instead of GitHub Secrets. Requires the runner to have SSM read access.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       gpg-private-key:
-        description: 'GPG Private Key'
-        required: true
+        description: 'GPG Private Key (legacy: use use-ssm-signing-keys instead)'
+        required: false
       gpg-private-key-passphrase:
-        description: 'GPG Private Key Passphrase'
+        description: 'GPG Private Key Passphrase (legacy: use use-ssm-signing-keys instead)'
         required: false
 
 jobs:
@@ -62,22 +67,76 @@ jobs:
           go-version: ${{ inputs.setup-go-version }}
           go-version-file: ${{ inputs.setup-go-version-file }}
           cache: false  # Disable caching to skip the post-cleanup step. saves circa 15 minutes
-      - name: Import GPG key
-        id: import_gpg
+
+      # --- Path A: Fetch GPG signing keys from AWS SSM (runner instance credentials) ---
+      - name: Fetch and import GPG signing key from SSM
+        if: inputs.use-ssm-signing-keys
+        id: ssm_gpg_import
+        run: |
+          GPG_PRIVATE_KEY=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-private-key" \
+            --with-decryption --query "Parameter.Value" --output text)
+          GPG_PASSPHRASE=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-private-key-passphrase" \
+            --with-decryption --query "Parameter.Value" --output text)
+          GPG_KEY_ID=$(aws ssm get-parameter \
+            --name "/terraform-registry-api-github-proxy/gpg-key-id" \
+            --query "Parameter.Value" --output text)
+
+          # Mask sensitive values to prevent leaking in logs
+          echo "::add-mask::${GPG_PRIVATE_KEY}"
+          echo "::add-mask::${GPG_PASSPHRASE}"
+
+          # Import the GPG key
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+
+          FINGERPRINT=$(gpg --list-keys --with-colons "${GPG_KEY_ID}" | awk -F: '/^fpr:/{print $10; exit}')
+
+          # Preset passphrase in GPG agent for batch signing (required for goreleaser)
+          KEYGRIP=$(gpg --batch --with-colons --with-keygrip --list-secret-keys "${GPG_KEY_ID}" | awk -F: '/^grp:/{print $10; exit}')
+          HEX_PASSPHRASE=$(echo -n "${GPG_PASSPHRASE}" | xxd -p -c 256 | tr -d '\n' | tr 'a-f' 'A-F')
+          gpg-connect-agent "PRESET_PASSPHRASE ${KEYGRIP} -1 ${HEX_PASSPHRASE}" /bye
+
+          echo "fingerprint=${FINGERPRINT}" >> "$GITHUB_OUTPUT"
+          echo "keyid=${GPG_KEY_ID}" >> "$GITHUB_OUTPUT"
+
+          gpg --armor --export "${FINGERPRINT}" > gpg-public-key.asc
+          echo "GPG Key ID: ${GPG_KEY_ID}"
+          echo "GPG Fingerprint: ${FINGERPRINT}"
+          echo "GPG public key exported to gpg-public-key.asc"
+          echo "GPG signing keys derived from SSM parameters"
+
+      # --- Path B: Legacy - Import GPG key from GitHub Secrets ---
+      - name: Import GPG key from secrets
+        if: ${{ !inputs.use-ssm-signing-keys }}
+        id: import_gpg_legacy
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.gpg-private-key }}
           passphrase: ${{ secrets.gpg-private-key-passphrase }}
-      - name: Export GPG public key for registry verification
+
+      - name: Export GPG public key for registry verification (legacy)
+        if: ${{ !inputs.use-ssm-signing-keys }}
         run: |
-          gpg --armor --export "${{ steps.import_gpg.outputs.fingerprint }}" > gpg-public-key.asc
-          echo "GPG Key ID: ${{ steps.import_gpg.outputs.keyid }}"
-          echo "GPG Fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+          gpg --armor --export "${{ steps.import_gpg_legacy.outputs.fingerprint }}" > gpg-public-key.asc
+          echo "GPG Key ID: ${{ steps.import_gpg_legacy.outputs.keyid }}"
+          echo "GPG Fingerprint: ${{ steps.import_gpg_legacy.outputs.fingerprint }}"
           echo "GPG public key exported to gpg-public-key.asc"
           echo ""
           echo "To update the Terraform registry proxy SSM parameters, run:"
-          echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-key-id --value '${{ steps.import_gpg.outputs.keyid }}' --type String --overwrite"
+          echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-key-id --value '${{ steps.import_gpg_legacy.outputs.keyid }}' --type String --overwrite"
           echo "  aws ssm put-parameter --name /terraform-registry-api-github-proxy/gpg-public-key --value \"\$(cat gpg-public-key.asc)\" --type SecureString --overwrite"
+
+      # --- Resolve GPG fingerprint from whichever path was used ---
+      - name: Set GPG fingerprint
+        id: gpg_fingerprint
+        run: |
+          if [ "${{ inputs.use-ssm-signing-keys }}" = "true" ]; then
+            echo "fingerprint=${{ steps.ssm_gpg_import.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "fingerprint=${{ steps.import_gpg_legacy.outputs.fingerprint }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - if: inputs.release-notes != true
         name: goreleaser release (without release notes)
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
@@ -85,7 +144,7 @@ jobs:
           args: release --clean ${{ inputs.goreleaser-release-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.gpg_fingerprint.outputs.fingerprint }}
       - if: inputs.release-notes
         id: release-notes-download
         name: Release Notes Download
@@ -100,4 +159,4 @@ jobs:
           args: release --release-notes ${{ steps.release-notes-download.outputs.download-path }}/release-notes.txt --clean ${{ inputs.goreleaser-release-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GPG_FINGERPRINT: ${{ steps.gpg_fingerprint.outputs.fingerprint }}


### PR DESCRIPTION
Supersedes #66, which was auto-closed as stale rather than rejected. Rebased onto current `main`.

## What this does

Adds a `use-ssm-signing-keys` input to the reusable goreleaser workflow. When set, signing material comes from AWS SSM using the self-hosted runner's existing instance credentials, instead of per-repository GitHub Secrets:

```
/terraform-registry-api-github-proxy/gpg-private-key
/terraform-registry-api-github-proxy/gpg-private-key-passphrase
/terraform-registry-api-github-proxy/gpg-key-id
```

These are the same parameters `registry.sweetgreen.engineering` already reads, so SSM becomes the single source of truth for signing across every `terraform-provider-*` repository and the registry itself.

## Why it matters beyond this repo

The registry serves **one** GPG public key to every provider it hosts. A provider signed with a different key fails signature validation, so the key has to be shared — and today that means copying a private key into each new repository's secrets by hand. That is both a manual step and an easy one to get wrong.

This came up because `sweetgreen/terraform-provider-automox` is a new provider that cannot publish without the key. With this change it needs nothing added to it.

## Safety

- `use-ssm-signing-keys` defaults to `false`, so any caller that does not opt in is unchanged. Both secrets become optional.
- The private key and passphrase are masked before use.
- The passphrase is preset into the GPG agent after import, which goreleaser needs for non-interactive signing.

Carries over the review feedback already addressed on #66.

## Why a new branch rather than reviving #66

`#66`'s branch cannot be brought up to date. This repository is a fork of `deploymenttheory/terraform-provider-microsoft365`, and merging `main` makes 182 upstream-authored commits newly reachable from the branch, which the committer-email ruleset rejects with 153 violations. A rebase has the same effect. Branching fresh from `main` sidesteps it, and the only conflict — `ghaction-import-gpg` moving to v7.0.0 on `main` — is resolved in favour of the newer pin.

## Sequencing

Requires sweetgreen/terraform-infrastructure#1130 to be applied **first**, and the two new parameters populated out of band, before any caller sets `use-ssm-signing-keys: true`. Same two-step shape as the Atlantis credential pattern: the parameter is created with a placeholder and `ignore_changes`, then the real value is set by hand.

## Test plan

- [ ] Apply terraform-infrastructure#1130 and populate the two SSM parameters
- [ ] Trigger a `workflow_dispatch` release to verify SSM-based signing end to end
- [ ] Confirm the released checksum signature validates against the registry's published public key