### PR TITLE
feat(ci): one-time workflow to migrate signing key into SSM

### DIFF
--- a/.github/workflows/migrate-signing-key-to-ssm.yml
+++ b/.github/workflows/migrate-signing-key-to-ssm.yml
@@ -21,10 +21,10 @@
 # Delete this workflow, and the gpg-signing-key-migration IAM role in
 # sweetgreen/terraform-infrastructure, once a release has signed from SSM.
 #
-# Hardening option: add `environment: signing-key-migration` to the job and put
-# a required-reviewer rule on that environment to gate each run. The IAM trust
-# policy would then need its `sub` narrowed to
-# `repo:sweetgreen/terraform-provider-microsoft365:environment:signing-key-migration`.
+# The job declares `environment: signing-key-migration`, and the IAM trust
+# policy keys on exactly that subject, so no other workflow in this repository
+# can assume the migration role. Add a required-reviewer rule to that
+# environment in repository settings to also gate each run on human approval.
 
 name: '🔑 Migrate signing key to SSM (one-time)'
 
@@ -51,6 +51,10 @@ jobs:
   migrate:
     name: 'Copy GPG signing key into SSM'
     runs-on: ubuntu-latest
+    # The IAM trust policy keys on this environment, so only this job can
+    # assume the migration role — not every workflow in the repository. Add a
+    # required-reviewer rule to the environment to also gate each run.
+    environment: signing-key-migration
     steps:
       - name: Check confirmation
         if: inputs.confirm != 'migrate'
@@ -77,12 +81,19 @@ jobs:
             echo "::error::GPG_PRIVATE_KEY_PASSPHRASE is empty; SSM cannot store an empty value."
             exit 1
           fi
-          echo "::add-mask::${GPG_PRIVATE_KEY}"
-          echo "::add-mask::${GPG_PRIVATE_KEY_PASSPHRASE}"
+          # Deliberately no ::add-mask:: here. Workflow commands are
+          # line-oriented, so echoing a multi-line armored key would register
+          # only its first line as a mask and print every remaining line to the
+          # log verbatim. Values read from secrets.* are already masked by
+          # GitHub, line by line, so manual masking is both redundant and unsafe.
 
           GNUPGHOME="$(mktemp -d)"
           export GNUPGHOME
           chmod 700 "$GNUPGHOME"
+          # Importing writes the private key to disk. The runner is ephemeral,
+          # but do not leave keyring material lying around for the rest of the
+          # job, and kill the agent so it stops caching the passphrase.
+          trap 'gpgconf --kill gpg-agent 2>/dev/null || true; rm -rf "$GNUPGHOME"' EXIT
           # GnuPG 2.1+ refuses loopback pinentry unless the agent opts in, and
           # without it the test-sign below fails for a perfectly good key.
           echo "allow-loopback-pinentry" > "$GNUPGHOME/gpg-agent.conf"
@@ -97,10 +108,12 @@ jobs:
           fi
 
           # Prove the passphrase actually unlocks the key by signing with it.
-          if ! echo test \
-            | gpg --batch --quiet --pinentry-mode loopback \
-                  --passphrase "$GPG_PRIVATE_KEY_PASSPHRASE" \
-                  --local-user "$FINGERPRINT" --sign --output /dev/null; then
+          # The passphrase goes in on stdin, not --passphrase, so it never
+          # appears in this process's argv.
+          if ! printf '%s' "$GPG_PRIVATE_KEY_PASSPHRASE" \
+            | gpg --batch --quiet --pinentry-mode loopback --passphrase-fd 0 \
+                  --local-user "$FINGERPRINT" --sign --output /dev/null \
+                  /dev/null; then
             echo "::error::GPG_PRIVATE_KEY_PASSPHRASE does not unlock ${FINGERPRINT}."
             exit 1
           fi
@@ -121,26 +134,39 @@ jobs:
         run: |
           set -euo pipefail
           umask 077
-          echo "::add-mask::${GPG_PRIVATE_KEY}"
-          echo "::add-mask::${GPG_PRIVATE_KEY_PASSPHRASE}"
+          # No ::add-mask:: — see the note in the verification step above.
 
           workdir="$(mktemp -d)"
           trap 'rm -rf "$workdir"' EXIT
 
+          # Calling this from an `if` suspends `set -e` for the whole body, so
+          # every step has to report failure explicitly or a failed write would
+          # fall through and the function would return the status of `echo`.
           put() {
-            name="$1"
-            value="$2"
+            local name="$1" value="$2" version
             jq -n --arg n "$name" --arg v "$value" \
-              '{Name:$n, Value:$v, Type:"SecureString", Overwrite:true}' > "$workdir/payload.json"
+              '{Name:$n, Value:$v, Type:"SecureString", Overwrite:true}' \
+              > "$workdir/payload.json" || return 1
             version="$(aws ssm put-parameter \
               --cli-input-json "file://$workdir/payload.json" \
-              --query Version --output text)"
+              --query Version --output text)" || { rm -f "$workdir/payload.json"; return 1; }
             rm -f "$workdir/payload.json"
             echo "  ${name} -> version ${version}"
           }
 
+          # Passphrase first, key second. These are two calls and the second can
+          # fail, so order them such that a partial run never leaves a fresh key
+          # paired with a stale passphrase. If only the passphrase lands, the key
+          # parameter still holds its placeholder and signing is simply not
+          # enabled yet, which is a safe state to retry from.
           echo "Writing signing key parameters:"
-          put "${PARAM_PREFIX}/gpg-private-key" "$GPG_PRIVATE_KEY"
-          put "${PARAM_PREFIX}/gpg-private-key-passphrase" "$GPG_PRIVATE_KEY_PASSPHRASE"
+          if ! put "${PARAM_PREFIX}/gpg-private-key-passphrase" "$GPG_PRIVATE_KEY_PASSPHRASE"; then
+            echo "::error::Failed writing the passphrase; the key parameter was left untouched. Safe to re-run."
+            exit 1
+          fi
+          if ! put "${PARAM_PREFIX}/gpg-private-key" "$GPG_PRIVATE_KEY"; then
+            echo "::error::Passphrase was written but the key was not. Re-run this workflow from the same secrets to converge."
+            exit 1
+          fi
 
           echo "Done. Release with use-ssm-signing-keys to confirm signing works end to end."

--- a/.github/workflows/migrate-signing-key-to-ssm.yml
+++ b/.github/workflows/migrate-signing-key-to-ssm.yml
@@ -1,0 +1,146 @@
+# One-time migration of the provider signing key from Actions secrets to SSM.
+#
+# GitHub secrets are write-only, so GPG_PRIVATE_KEY cannot be read back out by
+# hand to populate the SSM parameters that `use-ssm-signing-keys` reads. This
+# workflow moves the value directly from Actions into Parameter Store, so the
+# key never lands in a log, an artifact, or somebody's clipboard.
+#
+# Regenerating the key instead is not an option: the registry publishes a
+# single public key for every provider it serves, so a new key would invalidate
+# the signatures of every release already published for microsoft365, slackapp
+# and tableau.
+#
+# Runs on a GitHub-hosted runner deliberately. Those have no EC2 instance
+# credentials, so the scoped OIDC role below is the only AWS identity in play.
+#
+# ORDERING: run this only after sweetgreen/terraform-infrastructure#1585 has
+# applied. PutParameter creates a parameter that does not exist yet, so running
+# early would leave #1585 trying to create parameters that are already there,
+# and its apply would fail with ParameterAlreadyExists.
+#
+# Delete this workflow, and the gpg-signing-key-migration IAM role in
+# sweetgreen/terraform-infrastructure, once a release has signed from SSM.
+#
+# Hardening option: add `environment: signing-key-migration` to the job and put
+# a required-reviewer rule on that environment to gate each run. The IAM trust
+# policy would then need its `sub` narrowed to
+# `repo:sweetgreen/terraform-provider-microsoft365:environment:signing-key-migration`.
+
+name: '🔑 Migrate signing key to SSM (one-time)'
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'migrate' to confirm writing the signing key to SSM"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-east-1
+  # Full fingerprint of the key the registry publishes. The secret must match
+  # this, or we would silently install a key that verifies nothing.
+  EXPECTED_FINGERPRINT: 0AF4EFDB556A60C24AEEE1C10CD0B605A84D89CA
+  PARAM_PREFIX: /terraform-registry-api-github-proxy
+
+jobs:
+  migrate:
+    name: 'Copy GPG signing key into SSM'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check confirmation
+        if: inputs.confirm != 'migrate'
+        run: |
+          echo "::error::Confirmation phrase not matched; expected 'migrate'."
+          exit 1
+
+      # Fail before touching AWS if the secrets are not exactly what we expect.
+      # A wrong key or a passphrase that does not unlock it would install
+      # material that breaks every subsequent release, so prove both here.
+      - name: Verify the secrets hold a usable signing key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GPG_PRIVATE_KEY:-}" ]; then
+            echo "::error::GPG_PRIVATE_KEY secret is empty or unset."
+            exit 1
+          fi
+          # SSM rejects an empty parameter value, and the release workflow
+          # presets this passphrase into the agent, so it must be present.
+          if [ -z "${GPG_PRIVATE_KEY_PASSPHRASE:-}" ]; then
+            echo "::error::GPG_PRIVATE_KEY_PASSPHRASE is empty; SSM cannot store an empty value."
+            exit 1
+          fi
+          echo "::add-mask::${GPG_PRIVATE_KEY}"
+          echo "::add-mask::${GPG_PRIVATE_KEY_PASSPHRASE}"
+
+          GNUPGHOME="$(mktemp -d)"
+          export GNUPGHOME
+          chmod 700 "$GNUPGHOME"
+          # GnuPG 2.1+ refuses loopback pinentry unless the agent opts in, and
+          # without it the test-sign below fails for a perfectly good key.
+          echo "allow-loopback-pinentry" > "$GNUPGHOME/gpg-agent.conf"
+          gpgconf --reload gpg-agent 2>/dev/null || true
+
+          printf '%s' "$GPG_PRIVATE_KEY" | gpg --batch --quiet --import
+          FINGERPRINT="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+
+          if [ "$FINGERPRINT" != "$EXPECTED_FINGERPRINT" ]; then
+            echo "::error::Secret holds ${FINGERPRINT:-<none>}, expected ${EXPECTED_FINGERPRINT}."
+            exit 1
+          fi
+
+          # Prove the passphrase actually unlocks the key by signing with it.
+          if ! echo test \
+            | gpg --batch --quiet --pinentry-mode loopback \
+                  --passphrase "$GPG_PRIVATE_KEY_PASSPHRASE" \
+                  --local-user "$FINGERPRINT" --sign --output /dev/null; then
+            echo "::error::GPG_PRIVATE_KEY_PASSPHRASE does not unlock ${FINGERPRINT}."
+            exit 1
+          fi
+          echo "Verified signing key ${FINGERPRINT} and its passphrase."
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::224746450967:role/gpg-signing-key-migration-gha-role
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Values go in via --cli-input-json rather than --value so the key never
+      # appears in this process's argv.
+      - name: Write signing key parameters
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          umask 077
+          echo "::add-mask::${GPG_PRIVATE_KEY}"
+          echo "::add-mask::${GPG_PRIVATE_KEY_PASSPHRASE}"
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+
+          put() {
+            name="$1"
+            value="$2"
+            jq -n --arg n "$name" --arg v "$value" \
+              '{Name:$n, Value:$v, Type:"SecureString", Overwrite:true}' > "$workdir/payload.json"
+            version="$(aws ssm put-parameter \
+              --cli-input-json "file://$workdir/payload.json" \
+              --query Version --output text)"
+            rm -f "$workdir/payload.json"
+            echo "  ${name} -> version ${version}"
+          }
+
+          echo "Writing signing key parameters:"
+          put "${PARAM_PREFIX}/gpg-private-key" "$GPG_PRIVATE_KEY"
+          put "${PARAM_PREFIX}/gpg-private-key-passphrase" "$GPG_PRIVATE_KEY_PASSPHRASE"
+
+          echo "Done. Release with use-ssm-signing-keys to confirm signing works end to end."


### PR DESCRIPTION
## Why

#79 switches releases to read signing material from SSM. Those parameters cannot be populated by hand, because **the key is not retrievable**:

- the private half of `0CD0B605A84D89CA` is **not in AWS** — only `gpg-key-id` and `gpg-public-key` exist, and nothing in Secrets Manager
- its only known copy is this repo's `GPG_PRIVATE_KEY` / `GPG_PRIVATE_KEY_PASSPHRASE` secrets, and **GitHub secrets are write-only**
- **regenerating is not a workaround**: the registry serves a single global public key for every provider and version, so a new key fails verification for all 20 releases already published across microsoft365, slackapp and tableau

This workflow moves the value directly from Actions into Parameter Store, so the key never lands in a log, an artifact, or a clipboard.

## Safety

- **Runs on `ubuntu-latest`** deliberately — GitHub-hosted runners carry no EC2 instance credentials, so the scoped OIDC role is the only AWS identity in play
- **Proves the secrets are usable before writing**: the imported key's fingerprint must equal `0AF4EFDB556A60C24AEEE1C10CD0B605A84D89CA`, *and* the passphrase must actually unlock it via a test signature. Installing a wrong key or passphrase would break every later release, so it fails closed instead.
- **Values go in via `--cli-input-json`**, not `--value`, so the key never appears in the process's argv
- Both secrets are `::add-mask::`ed; the empty-passphrase case is rejected with a clear message rather than an opaque SSM `ValidationException`
- `workflow_dispatch` only, and requires typing `migrate` to confirm

The IAM role it assumes grants `ssm:PutParameter` — **no read** — on exactly the two signing parameters, and is assumable only from this repository.

## Ordering

⚠️ Requires sweetgreen/terraform-infrastructure#1588 (the OIDC role), and must run **only after #1585 has applied**. `PutParameter` creates a parameter that does not exist, so running early would leave #1585 trying to create parameters that are already there, failing with `ParameterAlreadyExists`.

## Lifecycle

Scaffolding, not a permanent workflow. Delete this file and the paired IAM role once a release has signed from SSM.

## Verification

- YAML parses; all `run` bodies pass `bash -n`
- The `--cli-input-json` write path was round-tripped against real SSM with a multi-line value containing quotes, backslashes and tabs — exact match, throwaway parameter deleted
- `allow-loopback-pinentry` is set in a temp `GNUPGHOME`, since GnuPG 2.1+ otherwise refuses loopback pinentry and the test-sign would fail for a perfectly good key
- Not executed end to end — that needs the real secrets and the merged IAM role

🤖 Generated with [Claude Code](https://claude.com/claude-code)