### PR TITLE
fix(ci): write the signing key to the Advanced parameter tier

### DIFF
--- a/.github/workflows/migrate-signing-key-to-ssm.yml
+++ b/.github/workflows/migrate-signing-key-to-ssm.yml
@@ -143,9 +143,9 @@ jobs:
           # every step has to report failure explicitly or a failed write would
           # fall through and the function would return the status of `echo`.
           put() {
-            local name="$1" value="$2" version
-            jq -n --arg n "$name" --arg v "$value" \
-              '{Name:$n, Value:$v, Type:"SecureString", Overwrite:true}' \
+            local name="$1" value="$2" tier="${3:-Standard}" version
+            jq -n --arg n "$name" --arg v "$value" --arg t "$tier" \
+              '{Name:$n, Value:$v, Type:"SecureString", Tier:$t, Overwrite:true}' \
               > "$workdir/payload.json" || return 1
             version="$(aws ssm put-parameter \
               --cli-input-json "file://$workdir/payload.json" \
@@ -164,7 +164,11 @@ jobs:
             echo "::error::Failed writing the passphrase; the key parameter was left untouched. Safe to re-run."
             exit 1
           fi
-          if ! put "${PARAM_PREFIX}/gpg-private-key" "$GPG_PRIVATE_KEY"; then
+          # Advanced tier: an armored private key exceeds the 4096-character
+          # ceiling on Standard, which fails with a ValidationException. The
+          # parameter is declared Advanced in Terraform too, so this matches
+          # rather than fights the managed configuration.
+          if ! put "${PARAM_PREFIX}/gpg-private-key" "$GPG_PRIVATE_KEY" Advanced; then
             echo "::error::Passphrase was written but the key was not. Re-run this workflow from the same secrets to converge."
             exit 1
           fi


### PR DESCRIPTION
## Why

The first migration run ([30662344432](https://github.com/sweetgreen/terraform-provider-microsoft365/actions/runs/30662344432)) failed writing the private key:

```
ValidationException: Standard tier parameters support a maximum parameter value
of 4096 characters. To create a larger parameter value, upgrade the parameter to
use the advanced-parameter tier.
```

An armored GPG private key exceeds that ceiling.

## What the run did prove

Everything before the write worked:

| Step | Result |
|---|---|
| Verify the secrets hold a usable signing key | ✅ |
| Configure AWS credentials (OIDC) | ✅ |
| Write signing key parameters | ❌ tier limit |

So the repo's `GPG_PRIVATE_KEY` really does hold key `0CD0B605A84D89CA`, the passphrase really does unlock it, and the environment-scoped OIDC role assumes correctly. Only the tier was wrong.

## The ordering held

`put()` writes the passphrase first, then the key. The failure landed exactly where that was designed to land:

```
gpg-private-key-passphrase   v2   real
gpg-private-key              v1   change-me   ← untouched
```

No fresh key stranded beside a stale passphrase. Re-running converges.

## Change

`put()` takes a tier argument defaulting to `Standard`; the key passes `Advanced`. The passphrase is short and stays on Standard, so no unnecessary per-parameter-month charge.

Pairs with sweetgreen/terraform-infrastructure#1589, which declares `tier = "Advanced"` on the same parameter so Terraform matches reality instead of planning the tier back down.

**Merge #1589 and let it apply before re-running this**, so the parameter is already Advanced when the write lands.

## Verification

- YAML parses; all `run` bodies pass `bash -n`
- ⚠️ The >4096-character round-trip against real SSM is **not** yet verified — the AWS SSO session expired mid-test. That size case is precisely what I failed to cover the first time (I round-tripped a *small* multi-line value and concluded the write path was proven), so it should be re-run before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)